### PR TITLE
Feat/new feat groups

### DIFF
--- a/src/modules/group/contract/group-contract.ts
+++ b/src/modules/group/contract/group-contract.ts
@@ -11,4 +11,5 @@ export interface IGroupContract {
   getGroupsCreatedByUserId: (userId: number) => Promise<Group[] | null>;
   enterInGroup: (groupId: number, userId: number) => Promise<Group>;
   getGroupById: (groupId: number) => Promise<Prisma.GroupGetPayload<{ include: { Users_In_Group: true } }> | null>;
+  getPublicGroupsWithVacancies: () => Promise<Group[]>;
 }

--- a/src/modules/group/repositories/in-memory-repository.ts
+++ b/src/modules/group/repositories/in-memory-repository.ts
@@ -3,7 +3,17 @@ import type { IGroupContract } from '../contract/group-contract';
 import type { CreateGroupDto } from '../dto/group-dto';
 
 export class InMemoryGroupRepository implements IGroupContract {
-  public group: Group[] = [];
+  public groups: Group[] = [];
+
+  public usersInGroup: {
+    id: number;
+    created_at: Date;
+    updated_at: Date;
+    user_id: number;
+    group_id: number;
+  }[] = [];
+
+  private usersInGroupCounter = 1;
 
   async createGroup({
     name,
@@ -13,21 +23,75 @@ export class InMemoryGroupRepository implements IGroupContract {
     userId,
   }: CreateGroupDto): Promise<Group> {
     const group = {
-      id: this.group.length + 1,
+      id: this.groups.length + 1,
       name,
       subject,
       description,
       privacy,
       user_id: userId,
+      user_count: 0, // Inicializa o contador
+      user_limit: 10, // Pode mudar conforme seu app
+      created_at: new Date(),
+      updated_at: new Date(),
     } as Group;
 
-    this.group.push(group);
+    this.groups.push(group);
     return group;
   }
 
   async getGroupsCreatedByUserId(userId: number): Promise<Group[] | null> {
-    const groups = this.group.filter((group) => group.user_id === userId);
-
+    const groups = this.groups.filter((group) => group.user_id === userId);
     return groups.length > 0 ? groups : null;
+  }
+
+  async enterInGroup(groupId: number, userId: number): Promise<Group> {
+    const group = this.groups.find((group) => group.id === groupId);
+
+    if (!group) {
+      throw new Error('Group not found');
+    }
+
+    // Atualizar o contador de usuários no grupo
+    group.user_count = (group.user_count || 0) + 1;
+    group.updated_at = new Date();
+
+    // Simular inserção em Users_In_Group
+    this.usersInGroup.push({
+      id: this.usersInGroupCounter++,
+      created_at: new Date(),
+      updated_at: new Date(),
+      user_id: userId,
+      group_id: groupId,
+    });
+
+    return group;
+  }
+
+  async getGroupById(
+    groupId: number,
+  ): Promise<
+    | (Group & {
+        Users_In_Group: {
+          id: number;
+          created_at: Date;
+          updated_at: Date;
+          user_id: number;
+          group_id: number;
+        }[];
+      })
+    | null
+  > {
+    const group = this.groups.find((group) => group.id === groupId);
+
+    if (!group) {
+      return null;
+    }
+
+    const usersInGroup = this.usersInGroup.filter((entry) => entry.group_id === groupId);
+
+    return {
+      ...group,
+      Users_In_Group: usersInGroup,
+    };
   }
 }

--- a/src/modules/group/repositories/in-memory-repository.ts
+++ b/src/modules/group/repositories/in-memory-repository.ts
@@ -29,8 +29,8 @@ export class InMemoryGroupRepository implements IGroupContract {
       description,
       privacy,
       user_id: userId,
-      user_count: 0, // Inicializa o contador
-      user_limit: 10, // Pode mudar conforme seu app
+      user_count: 0, 
+      user_limit: 10, 
       created_at: new Date(),
       updated_at: new Date(),
     } as Group;
@@ -51,11 +51,9 @@ export class InMemoryGroupRepository implements IGroupContract {
       throw new Error('Group not found');
     }
 
-    // Atualizar o contador de usuários no grupo
     group.user_count = (group.user_count || 0) + 1;
     group.updated_at = new Date();
 
-    // Simular inserção em Users_In_Group
     this.usersInGroup.push({
       id: this.usersInGroupCounter++,
       created_at: new Date(),

--- a/src/modules/group/repositories/in-memory-repository.ts
+++ b/src/modules/group/repositories/in-memory-repository.ts
@@ -29,8 +29,8 @@ export class InMemoryGroupRepository implements IGroupContract {
       description,
       privacy,
       user_id: userId,
-      user_count: 0, 
-      user_limit: 10, 
+      user_count: 0,
+      user_limit: 10,
       created_at: new Date(),
       updated_at: new Date(),
     } as Group;
@@ -65,9 +65,7 @@ export class InMemoryGroupRepository implements IGroupContract {
     return group;
   }
 
-  async getGroupById(
-    groupId: number,
-  ): Promise<
+  async getGroupById(groupId: number): Promise<
     | (Group & {
         Users_In_Group: {
           id: number;
@@ -85,11 +83,23 @@ export class InMemoryGroupRepository implements IGroupContract {
       return null;
     }
 
-    const usersInGroup = this.usersInGroup.filter((entry) => entry.group_id === groupId);
+    const usersInGroup = this.usersInGroup.filter(
+      (entry) => entry.group_id === groupId,
+    );
 
     return {
       ...group,
       Users_In_Group: usersInGroup,
     };
+  }
+
+  async getPublicGroupsWithVacancies(): Promise<Group[]> {
+    const groupsWithVacancies = this.groups.filter(
+      (group) =>
+        group.privacy === 'PUBLIC' &&
+        (group.user_count || 0) < (group.user_limit || 10),
+    );
+
+    return groupsWithVacancies;
   }
 }

--- a/src/modules/group/repositories/prisma-repository.ts
+++ b/src/modules/group/repositories/prisma-repository.ts
@@ -35,7 +35,9 @@ class GroupRepository implements IGroupContract {
     return groups.length > 0 ? groups : [];
   }
 
-  async getGroupById(groupId: number): Promise<Prisma.GroupGetPayload<{ include: { Users_In_Group: true } }> | null> {
+  async getGroupById(groupId: number): Promise<Prisma.GroupGetPayload<{
+    include: { Users_In_Group: true };
+  }> | null> {
     const group = await this.groupRepository.group.findUnique({
       where: {
         id: groupId,
@@ -68,6 +70,16 @@ class GroupRepository implements IGroupContract {
 
       return group;
     });
+  }
+
+  async getPublicGroupsWithVacancies(): Promise<Group[]> {
+    const groups = await this.groupRepository.$queryRaw<Group[]>`
+    SELECT * FROM "Group"
+    WHERE privacy = 'PUBLIC'
+    AND user_count < user_limit
+  `;
+
+    return groups.length > 0 ? groups : [];
   }
 }
 

--- a/src/modules/group/services/group-service.spec.ts
+++ b/src/modules/group/services/group-service.spec.ts
@@ -3,6 +3,9 @@ import { GroupService } from './group-service';
 import { InvalidPrivacyTypeError } from './errors/invalid-privacy-type-error';
 import { UserHasReachedTheLimitError } from './errors/user-has-reached-the-limit-error';
 import { InMemoryGroupRepository } from '../repositories/in-memory-repository';
+import { GroupNotFoundError } from './errors/group-not-found-error';
+import { UserAlreadyInGroupError } from './errors/user-already-in-group-error';
+import { GroupHasReachedTheLimitError } from './errors/group-has-reached-the-limit-error';
 
 let groupRepository: InMemoryGroupRepository;
 let sut: GroupService;
@@ -70,5 +73,84 @@ describe('GroupService', () => {
     if (result.isLeft()) {
       expect(result.value).toBeInstanceOf(UserHasReachedTheLimitError);
     }
+  });
+  it('should be able to enter in a group', async () => {
+    const group = await groupRepository.createGroup({
+      name: 'Study Group',
+      subject: 'ALGORITHMS',
+      description: 'Description',
+      privacy: 'PUBLIC',
+      userId: 1,
+    });
+
+    const result = await sut.enterInGroup(group.id, 2);
+
+    expect(result.isRight()).toBeTruthy();
+    if (result.isRight()) {
+      expect(result.value.id).toBe(group.id);
+    }
+  });
+
+  it('should not be able to enter a non-existing group', async () => {
+    const result = await sut.enterInGroup(999, 1);
+
+    expect(result.isLeft()).toBeTruthy();
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(GroupNotFoundError);
+    }
+  });
+
+  it('should not allow a user to enter twice in the same group', async () => {
+    const group = await groupRepository.createGroup({
+      name: 'Study Group',
+      subject: 'ALGORITHMS',
+      description: 'Description',
+      privacy: 'PUBLIC',
+      userId: 1,
+    });
+
+    await sut.enterInGroup(group.id, 2);
+
+    const result = await sut.enterInGroup(group.id, 2);
+    expect(result.isLeft()).toBeTruthy();
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(UserAlreadyInGroupError);
+    }
+  });
+
+  it('should not allow user to enter a full group (user_count > user_limit)', async () => {
+    const group = await groupRepository.createGroup({
+      name: 'Small Group',
+      subject: 'ALGORITHMS',
+      description: 'Only 1 user allowed',
+      privacy: 'PUBLIC',
+      userId: 1,
+    });
+
+    group.user_limit = 1;
+    group.user_count = 1;
+
+    const result = await sut.enterInGroup(group.id, 3);
+
+    expect(result.isLeft()).toBeTruthy();
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(GroupHasReachedTheLimitError);
+    }
+  });
+
+  it('should increase user_count when a user enters the group', async () => {
+    const group = await groupRepository.createGroup({
+      name: 'Growing Group',
+      subject: 'ALGORITHMS',
+      description: 'Lots of people',
+      privacy: 'PUBLIC',
+      userId: 1,
+    });
+
+    await sut.enterInGroup(group.id, 2);
+
+    const updatedGroup = await groupRepository.getGroupById(group.id);
+
+    expect(updatedGroup?.user_count).toBe(1); 
   });
 });

--- a/src/modules/group/services/group-service.spec.ts
+++ b/src/modules/group/services/group-service.spec.ts
@@ -127,8 +127,12 @@ describe('GroupService', () => {
       userId: 1,
     });
 
-    group.user_limit = 1;
-    group.user_count = 1;
+    const groupInRepo = groupRepository.groups.find((g) => g.id === group.id);
+
+    if (groupInRepo) {
+      groupInRepo.user_limit = 1;
+      groupInRepo.user_count = 1;
+    }
 
     const result = await sut.enterInGroup(group.id, 3);
 
@@ -151,6 +155,77 @@ describe('GroupService', () => {
 
     const updatedGroup = await groupRepository.getGroupById(group.id);
 
-    expect(updatedGroup?.user_count).toBe(1); 
+    expect(updatedGroup?.user_count).toBe(1);
+  });
+
+  it('should return public groups with vacancies', async () => {
+    await groupRepository.createGroup({
+      name: 'Public Group 1',
+      subject: 'ALGORITHMS',
+      description: 'Description',
+      privacy: 'PUBLIC',
+      userId: 1,
+    });
+
+    await groupRepository.createGroup({
+      name: 'Private Group 2',
+      subject: 'ALGORITHMS',
+      description: 'Description',
+      privacy: 'PRIVATE',
+      userId: 2,
+    });
+
+    const result = await sut.getPublicGroupsWithVacancies();
+
+    expect(result.isRight()).toBeTruthy();
+    if (result.isRight()) {
+      expect(result.value.length).toBe(1);
+      expect(result.value[0].name).toBe('Public Group 1');
+    }
+  });
+
+  it('should return an empty array if there are no public groups with vacancies', async () => {
+    await groupRepository.createGroup({
+      name: 'Full Group',
+      subject: 'ALGORITHMS',
+      description: 'Description',
+      privacy: 'PUBLIC',
+      userId: 1,
+    });
+
+    const groupInRepo = groupRepository.groups.find(
+      (g) => g.name === 'Full Group',
+    );
+
+    if (groupInRepo) {
+      groupInRepo.user_limit = 1;
+      groupInRepo.user_count = 1;
+    }
+
+    const result = await sut.getPublicGroupsWithVacancies();
+
+    expect(result.isRight()).toBeTruthy();
+    if (result.isRight()) {
+      expect(result.value.length).toBe(0);
+    }
+  });
+
+  it('should return an empty array if there are no public groups', async () => {
+    await groupRepository.createGroup({
+      name: 'Full Group',
+      subject: 'ALGORITHMS',
+      description: 'Description',
+      privacy: 'PRIVATE',
+      userId: 1,
+    });
+
+    const result = await sut.getPublicGroupsWithVacancies();
+
+    const groups = result.value;
+
+    expect(result.isRight()).toBeTruthy();
+    if (result.isRight()) {
+      expect(groups!.length).toBe(0);
+    }
   });
 });

--- a/src/modules/group/services/group-service.ts
+++ b/src/modules/group/services/group-service.ts
@@ -63,12 +63,18 @@ export class GroupService {
       return left(new UserAlreadyInGroupError());
     }
 
-    if (groupFound.user_count > groupFound.user_limit) {
+    if (groupFound.user_count >= groupFound.user_limit) {
       return left(new GroupHasReachedTheLimitError());
     }
 
     const group = await this.groupRepository.enterInGroup(groupId, userId);
 
     return right(group);
+  }
+
+  async getPublicGroupsWithVacancies(): Promise<Either<null, Group[]>> {
+    const groups = await this.groupRepository.getPublicGroupsWithVacancies();
+
+    return right(groups.length > 0 ? groups : []);
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the group management module, focusing on adding new functionalities and improving existing ones. The most important changes include adding a method to fetch public groups with vacancies, updating the in-memory and Prisma repositories to support this new functionality, and enhancing the group service and its tests.

### New functionalities:
* [`src/modules/group/contract/group-contract.ts`](diffhunk://#diff-cabaa07ab3761594a88c73b3b792f82904be8a6282c6334b5931fcfb5e4f93adR14): Added `getPublicGroupsWithVacancies` method to the `IGroupContract` interface.

### Repository updates:
* `src/modules/group/repositories/in-memory-repository.ts`: 
  - Added `usersInGroup` array and `usersInGroupCounter` to manage users in groups.
  - Updated `createGroup` method to initialize `user_count`, `user_limit`, `created_at`, and `updated_at` fields.
  - Implemented `enterInGroup`, `getGroupById`, and `getPublicGroupsWithVacancies` methods. [[1]](diffhunk://#diff-cfc0dc06ecf158f2209aaca0bfa949455c09e5193a8436d92168d3dd3bfc0c7cL6-R16) [[2]](diffhunk://#diff-cfc0dc06ecf158f2209aaca0bfa949455c09e5193a8436d92168d3dd3bfc0c7cL16-R104)

* `src/modules/group/repositories/prisma-repository.ts`: 
  - Implemented `getPublicGroupsWithVacancies` method to fetch public groups with vacancies using a raw SQL query. [[1]](diffhunk://#diff-cfd196fe017ea6d1004ed4102e75195e7490658e61fa5a9b96bc864acddac3acL38-R40) [[2]](diffhunk://#diff-cfd196fe017ea6d1004ed4102e75195e7490658e61fa5a9b96bc864acddac3acR74-R83)

### Service and test enhancements:
* `src/modules/group/services/group-service.ts`: 
  - Added `getPublicGroupsWithVacancies` method to the `GroupService` class.

* `src/modules/group/services/group-service.spec.ts`: 
  - Added tests for entering a group, handling non-existing groups, preventing duplicate entries, handling full groups, and fetching public groups with vacancies. [[1]](diffhunk://#diff-8500f25718432398411eb4d8c56ce210833de7f1bda3c9dd897423b8a7d9decaR6-R8) [[2]](diffhunk://#diff-8500f25718432398411eb4d8c56ce210833de7f1bda3c9dd897423b8a7d9decaR77-R230)