### PR TITLE
Feat/entry code

### DIFF
--- a/prisma/migrations/20250411024625_insert_new_column/migration.sql
+++ b/prisma/migrations/20250411024625_insert_new_column/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[entry_code]` on the table `groups` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "groups" ADD COLUMN     "entry_code" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "groups_entry_code_key" ON "groups"("entry_code");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model Group {
   name        String
   description String?
   subject     Subject
+  entry_code  String? @unique
 
   user_limit Int     @default(5)
   user_count Int     @default(0)

--- a/src/modules/group/contract/group-contract.ts
+++ b/src/modules/group/contract/group-contract.ts
@@ -7,6 +7,7 @@ export interface IGroupContract {
     subject,
     description,
     privacy,
+    entryCode,
   }: CreateGroupDto) => Promise<Group>;
   getGroupsCreatedByUserId: (userId: number) => Promise<Group[] | null>;
   enterInGroup: (groupId: number, userId: number) => Promise<Group>;

--- a/src/modules/group/dto/group-dto.ts
+++ b/src/modules/group/dto/group-dto.ts
@@ -7,4 +7,5 @@ export type CreateGroupDto = {
 
   privacy?: Privacy;
   userId: number;
+  entryCode?: string;
 };

--- a/src/modules/group/repositories/in-memory-repository.ts
+++ b/src/modules/group/repositories/in-memory-repository.ts
@@ -21,6 +21,7 @@ export class InMemoryGroupRepository implements IGroupContract {
     description,
     privacy,
     userId,
+    entryCode
   }: CreateGroupDto): Promise<Group> {
     const group = {
       id: this.groups.length + 1,
@@ -33,6 +34,7 @@ export class InMemoryGroupRepository implements IGroupContract {
       user_limit: 10,
       created_at: new Date(),
       updated_at: new Date(),
+      entry_code: privacy === 'PRIVATE' ? entryCode : undefined,
     } as Group;
 
     this.groups.push(group);

--- a/src/modules/group/repositories/prisma-repository.ts
+++ b/src/modules/group/repositories/prisma-repository.ts
@@ -11,6 +11,7 @@ class GroupRepository implements IGroupContract {
     description,
     privacy,
     userId,
+    entryCode
   }: CreateGroupDto): Promise<Group> {
     const group = await this.groupRepository.group.create({
       data: {
@@ -19,6 +20,7 @@ class GroupRepository implements IGroupContract {
         description,
         privacy,
         user_id: userId,
+        entry_code: entryCode,
       },
     });
 

--- a/src/modules/group/services/group-service.spec.ts
+++ b/src/modules/group/services/group-service.spec.ts
@@ -228,4 +228,19 @@ describe('GroupService', () => {
       expect(groups!.length).toBe(0);
     }
   });
+
+  it('should an code if the group is private', async () => {
+    const result = await sut.createGroup({
+      name: 'Study Group',
+      subject: 'ALGORITHMS',
+      description: 'Group for math lovers',
+      privacy: 'PRIVATE',
+      userId: 1,
+    });
+
+    expect(result.isRight()).toBeTruthy();
+    if (result.isRight()) {
+      expect(result.value.entry_code).toBeDefined();
+    }
+  });
 });

--- a/src/modules/group/services/group-service.ts
+++ b/src/modules/group/services/group-service.ts
@@ -7,6 +7,7 @@ import { UserHasReachedTheLimitError } from './errors/user-has-reached-the-limit
 import { GroupNotFoundError } from './errors/group-not-found-error';
 import { GroupHasReachedTheLimitError } from './errors/group-has-reached-the-limit-error';
 import { UserAlreadyInGroupError } from './errors/user-already-in-group-error';
+import { generateRandomCode } from '../utils/random-code';
 
 export class GroupService {
   constructor(private groupRepository: IGroupContract) {}
@@ -17,6 +18,7 @@ export class GroupService {
     description,
     privacy,
     userId,
+    entryCode,
   }: CreateGroupDto): Promise<
     Either<InvalidPrivacyTypeError | UserHasReachedTheLimitError, Group>
   > {
@@ -37,6 +39,7 @@ export class GroupService {
       description,
       privacy,
       userId,
+      entryCode: privacy === 'PRIVATE' ? generateRandomCode() : undefined,
     });
 
     return right(group);

--- a/src/modules/group/utils/random-code.ts
+++ b/src/modules/group/utils/random-code.ts
@@ -1,0 +1,10 @@
+export function generateRandomCode(): string {
+  const characters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < 8; i++) {
+    const randomIndex = Math.floor(Math.random() * characters.length);
+    result += characters[randomIndex];
+  }
+  return result;
+}


### PR DESCRIPTION
This pull request introduces the implementation of an `entry_code` for private groups in the system. The changes span across database schema modifications, updates to TypeScript interfaces and classes, and the addition of a utility function for generating random codes.

Database schema changes:

* Added a new column `entry_code` to the `groups` table and created a unique index on this column (`prisma/migrations/20250411024625_insert_new_column/migration.sql`).
* Updated the `Group` model in the Prisma schema to include the `entry_code` field (`prisma/schema.prisma`).

TypeScript interface and class updates:

* Added `entryCode` to the `CreateGroupDto` type (`src/modules/group/dto/group-dto.ts`).
* Updated the `IGroupContract` interface to include `entryCode` in the `CreateGroupDto` parameter (`src/modules/group/contract/group-contract.ts`).
* Modified the `InMemoryGroupRepository` and `GroupRepository` classes to handle the `entryCode` field (`src/modules/group/repositories/in-memory-repository.ts`, `src/modules/group/repositories/prisma-repository.ts`). [[1]](diffhunk://#diff-cfc0dc06ecf158f2209aaca0bfa949455c09e5193a8436d92168d3dd3bfc0c7cR24) [[2]](diffhunk://#diff-cfc0dc06ecf158f2209aaca0bfa949455c09e5193a8436d92168d3dd3bfc0c7cR37) [[3]](diffhunk://#diff-cfd196fe017ea6d1004ed4102e75195e7490658e61fa5a9b96bc864acddac3acR14) [[4]](diffhunk://#diff-cfd196fe017ea6d1004ed4102e75195e7490658e61fa5a9b96bc864acddac3acR23)

Service and utility function additions:

* Updated the `GroupService` class to generate a random `entry_code` for private groups using a newly added utility function (`src/modules/group/services/group-service.ts`). [[1]](diffhunk://#diff-df767a3167026626c0b04b228ab49f46bf86e60a101841340b308bbb9eaf2f99R10) [[2]](diffhunk://#diff-df767a3167026626c0b04b228ab49f46bf86e60a101841340b308bbb9eaf2f99R21) [[3]](diffhunk://#diff-df767a3167026626c0b04b228ab49f46bf86e60a101841340b308bbb9eaf2f99R42)
* Added the `generateRandomCode` utility function to create random entry codes (`src/modules/group/utils/random-code.ts`).

Testing:

* Added a test case to ensure that a code is generated for private groups (`src/modules/group/services/group-service.spec.ts`).