### PR TITLE
Feat/group new methods

### DIFF
--- a/src/modules/group/repositories/in-memory-repository.ts
+++ b/src/modules/group/repositories/in-memory-repository.ts
@@ -105,11 +105,60 @@ export class InMemoryGroupRepository implements IGroupContract {
     return groupsWithVacancies;
   }
 
-  async getPrivateGroupForEntryCode(entryCode: string): Promise<Group | null> {
+  async getPrivateGroupForEntryCode(entryCode: string): Promise<
+    | (Group & {
+        Users_In_Group: {
+          id: number;
+          created_at: Date;
+          updated_at: Date;
+          user_id: number;
+          group_id: number;
+        }[];
+      })
+    | null
+  > {
     const group = this.groups.find(
       (group) => group.entry_code === entryCode && group.privacy === 'PRIVATE',
     );
 
-    return group || null;
+    if (!group) {
+      return null;
+    }
+
+    const usersInGroup = this.usersInGroup.filter(
+      (entry) => entry.group_id === group.id,
+    );
+
+    return {
+      ...group,
+      Users_In_Group: usersInGroup,
+    };
+  }
+
+  async enterInPrivateGroup(entryCode: string, userId: number): Promise<Group> {
+    const group = this.groups.find(
+      (group) => group.entry_code === entryCode && group.privacy === 'PRIVATE',
+    );
+
+    if (!group) {
+      throw new Error('Private group not found or invalid entry code');
+    }
+
+    if ((group.user_count || 0) >= (group.user_limit || 10)) {
+      throw new Error('Group has reached its user limit');
+    }
+
+    group.user_count = (group.user_count || 0) + 1;
+    group.updated_at = new Date();
+
+    this.usersInGroup.push({
+      id: this.usersInGroupCounter++,
+      created_at: new Date(),
+      updated_at: new Date(),
+      user_id: userId,
+      group_id: group.id,
+    });
+
+    return group;
   }
 }

--- a/src/modules/group/services/group-service.spec.ts
+++ b/src/modules/group/services/group-service.spec.ts
@@ -313,4 +313,67 @@ describe('GroupService', () => {
       }
     }
   });
+
+  it('should return a group by entry code', async () => {
+    const result = await sut.createGroup({
+      name: 'Study Group',
+      subject: 'ALGORITHMS',
+      description: 'Group for math lovers',
+      privacy: 'PRIVATE',
+      userId: 1,
+    });
+
+    if (result.isRight()) {
+      const createdGroup = result.value;
+
+      const groupFound = await sut.getPrivateGroupForEntryCode(
+        createdGroup.entry_code as string,
+      );
+
+      expect(groupFound.isRight()).toBeTruthy();
+      if (groupFound.isRight()) {
+        expect(groupFound.value.id).toBe(createdGroup.id);
+        expect(groupFound.value.entry_code).toBe(createdGroup.entry_code);
+      }
+    }
+  });
+
+  it('should not return a group if the entry code is invalid', async () => {
+    const result = await sut.getPrivateGroupForEntryCode('INVALID_CODE');
+
+    expect(result.isLeft()).toBeTruthy();
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(GroupNotFoundError);
+    }
+  });
+
+  it('should user enter in a group with entry code', async () => {
+    const group = await groupRepository.createGroup({
+      name: 'Study Group',
+      subject: 'ALGORITHMS',
+      description: 'Group for math lovers',
+      privacy: 'PRIVATE',
+      userId: 1,
+    });
+    const result = await sut.enterInPrivateGroup(group.entry_code!, 2);
+
+    expect(result.isRight()).toBeTruthy();
+    if (result.isRight()) {
+      expect(result.value.id).toBe(group.id);
+    }
+    const groupFound = await groupRepository.getGroupById(group.id);
+    expect(groupFound).toBeDefined();
+    if (groupFound) {
+      expect(groupFound.user_count).toBe(1);
+    }
+  });
+
+  it('should not allow user to enter a group with invalid entry code', async () => {
+    const result = await sut.enterInPrivateGroup('INVALID_CODE', 1);
+
+    expect(result.isLeft()).toBeTruthy();
+    if (result.isLeft()) {
+      expect(result.value).toBeInstanceOf(GroupNotFoundError);
+    }
+  });
 });


### PR DESCRIPTION
This pull request introduces significant changes to the `InMemoryGroupRepository` and its associated tests in the `GroupService`. The main changes include enhancing the method for retrieving a private group by entry code, adding a new method for entering a private group, and updating the test suite to cover these new functionalities.

Enhancements to `InMemoryGroupRepository`:

* Modified `getPrivateGroupForEntryCode` to return a group with its associated users if found, or `null` if not found.
* Added a new method `enterInPrivateGroup` to allow users to join a private group using an entry code, with error handling for invalid codes and full groups.

Updates to `GroupService` tests:

* Added a test case to verify that a group can be retrieved by its entry code.
* Added a test case to ensure that an invalid entry code returns a `GroupNotFoundError`.
* Added a test case to check that a user can successfully enter a group using a valid entry code.
* Added a test case to verify that an invalid entry code prevents a user from entering a group, returning a `GroupNotFoundError`.